### PR TITLE
Build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,273 @@
+## Core latex/pdflatex auxiliary files:
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+.*.lb
+
+## Intermediate documents:
+*.dvi
+*.xdv
+*-converted-to.*
+# these rules might exclude image files for figures etc.
+# *.ps
+# *.eps
+# *.pdf
+
+## Generated if empty string is given at "Please type another file name for output:"
+.pdf
+
+## Bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.run.xml
+
+## Build tool auxiliary files:
+*.fdb_latexmk
+*.synctex
+*.synctex(busy)
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+
+## Build tool directories for auxiliary files
+# latexrun
+latex.out/
+
+## Auxiliary and intermediate files from other packages:
+# algorithms
+*.alg
+*.loa
+
+# achemso
+acs-*.bib
+
+# amsthm
+*.thm
+
+# beamer
+*.nav
+*.pre
+*.snm
+*.vrb
+
+# changes
+*.soc
+
+# comment
+*.cut
+
+# cprotect
+*.cpt
+
+# elsarticle (documentclass of Elsevier journals)
+*.spl
+
+# endnotes
+*.ent
+
+# fixme
+*.lox
+
+# feynmf/feynmp
+*.mf
+*.mp
+*.t[1-9]
+*.t[1-9][0-9]
+*.tfm
+
+#(r)(e)ledmac/(r)(e)ledpar
+*.end
+*.?end
+*.[1-9]
+*.[1-9][0-9]
+*.[1-9][0-9][0-9]
+*.[1-9]R
+*.[1-9][0-9]R
+*.[1-9][0-9][0-9]R
+*.eledsec[1-9]
+*.eledsec[1-9]R
+*.eledsec[1-9][0-9]
+*.eledsec[1-9][0-9]R
+*.eledsec[1-9][0-9][0-9]
+*.eledsec[1-9][0-9][0-9]R
+
+# glossaries
+*.acn
+*.acr
+*.glg
+*.glo
+*.gls
+*.glsdefs
+*.lzo
+*.lzs
+
+# uncomment this for glossaries-extra (will ignore makeindex's style files!)
+# *.ist
+
+# gnuplottex
+*-gnuplottex-*
+
+# gregoriotex
+*.gaux
+*.gtex
+
+# htlatex
+*.4ct
+*.4tc
+*.idv
+*.lg
+*.trc
+*.xref
+
+# hyperref
+*.brf
+
+# knitr
+*-concordance.tex
+# TODO Comment the next line if you want to keep your tikz graphics files
+*.tikz
+*-tikzDictionary
+
+# listings
+*.lol
+
+# luatexja-ruby
+*.ltjruby
+
+# makeidx
+*.idx
+*.ilg
+*.ind
+
+# minitoc
+*.maf
+*.mlf
+*.mlt
+*.mtc[0-9]*
+*.slf[0-9]*
+*.slt[0-9]*
+*.stc[0-9]*
+
+# minted
+_minted*
+*.pyg
+
+# morewrites
+*.mw
+
+# nomencl
+*.nlg
+*.nlo
+*.nls
+
+# pax
+*.pax
+
+# pdfpcnotes
+*.pdfpc
+
+# sagetex
+*.sagetex.sage
+*.sagetex.py
+*.sagetex.scmd
+
+# scrwfile
+*.wrt
+
+# sympy
+*.sout
+*.sympy
+sympy-plots-for-*.tex/
+
+# pdfcomment
+*.upa
+*.upb
+
+# pythontex
+*.pytxcode
+pythontex-files-*/
+
+# tcolorbox
+*.listing
+
+# thmtools
+*.loe
+
+# TikZ & PGF
+*.dpth
+*.md5
+*.auxlock
+
+# todonotes
+*.tdo
+
+# vhistory
+*.hst
+*.ver
+
+# easy-todo
+*.lod
+
+# xcolor
+*.xcp
+
+# xmpincl
+*.xmpi
+
+# xindy
+*.xdy
+
+# xypic precompiled matrices and outlines
+*.xyc
+*.xyd
+
+# endfloat
+*.ttt
+*.fff
+
+# Latexian
+TSWLatexianTemp*
+
+## Editors:
+# WinEdt
+*.bak
+*.sav
+
+# Texpad
+.texpadtmp
+
+# LyX
+*.lyx~
+
+# Kile
+*.backup
+
+# gummi
+.*.swp
+
+# KBibTeX
+*~[0-9]*
+
+# auto folder when using emacs and auctex
+./auto/*
+*.el
+
+# expex forward references with \gathertags
+*-tags.tex
+
+# standalone packages
+*.sta
+
+# Makeindex log files
+*.lpz

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+manuscript = main
+references = $(wildcard *.bib)
+latexopt   = -halt-on-error -file-line-error
+
+all: all-via-pdf
+
+all-via-pdf: $(manuscript).tex $(references)
+	pdflatex $(manuscript).tex --shell-escape
+	bibtex $(manuscript).aux
+	pdflatex $(latexopt) $<
+	pdflatex $(latexopt) $<
+
+all-via-dvi: 
+	latex $(latexopt) $(manuscript)
+	bibtex $(manuscript).aux
+	latex $(latexopt) $(manuscript)
+	latex $(latexopt) $(manuscript)
+	dvipdf $(manuscript)
+
+epub: 
+	latex $(latexopt) $(manuscript)
+	bibtex $(manuscript).aux
+	mk4ht htlatex $(manuscript).tex 'xhtml,charset=utf-8,pmathml' ' -cunihtf -utf8 -cvalidate'
+	ebook-convert $(manuscript).html $(manuscript).epub
+
+clean:
+	rm -f *.fdb_latexmk *.fls *.pdf *.glo *.ist *.log *.dvi *.toc *.aux *.gz *.out *.log *.bbl *.blg *.log *.spl *~ *.spl *.zip *.acn *.glo *.ist *.epub
+
+realclean: clean
+	rm -rf $(manuscript).dvi
+	rm -f $(manuscript).pdf
+
+%.ps :%.eps
+	convert $< $@
+
+%.png :%.eps
+	convert $< $@
+
+zip:
+	zip paper.zip *.tex *.eps *.bib
+
+.PHONY: all clean

--- a/main.tex
+++ b/main.tex
@@ -188,7 +188,7 @@
 %%%%%%%%%%%%%%%% BIBLIOGRAPHY %%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \bibliographystyle{IEEEtran} % Dunno what format they want this!!! -MK 9/19/16
-\bibliography{refs.bib}
+\bibliography{refs}
 
 
 

--- a/refs.bib
+++ b/refs.bib
@@ -1312,13 +1312,22 @@ Year = {2010}
 };
 
 
-@ARTICLE{Goorley2016,
-	author = {T. Goorley, and M. James, and T. Booth, and F. Brown, and J. Bull, and L.J. Cox, and J. Durkee, and J. Elson, and M. Fensin, and R.A. Forster, and J. Hendricks, and H.G. Hughes, and R. Johns, and B. Kiedrowski, and R. Martz, and S. Mashnik, and G. McKinney, and D. Pelowitz, and R. Prael, and J. Sweezy, and L. Waters, and T. Wilcox, and T. Zukaitis},
-	title = {Features of {MCNP6}},
-	journal = {Annals of Nuclear Energy},
-	volume={87},
-	pages = {772-783},
-	year = {2016}
+@article{Goorley2016,
+	author = {T. Goorley and M. James and T. Booth and F. Brown and J. Bull and L. J. Cox and J. Durkee and J. Elson and M. Fensin and R. A. Forster and J. Hendricks and H. G. Hughes and R. Johns and B. Kiedrowski and R. Martz and S. Mashnik and G. McKinney and D. Pelowitz and R. Prael and J. Sweezy and L. Waters and T. Wilcox and T. Zukaitis},
+	title = {Initial MCNP6 Release Overview},
+	journal = {Nuclear Technology},
+	volume = {180},
+	number = {3},
+	pages = {298-315},
+	year  = {2012},
+	publisher = {Taylor & Francis},
+	doi = {10.13182/NT11-135},
+	URL = { 
+	https://doi.org/10.13182/NT11-135
+	},
+	eprint = { 
+	https://doi.org/10.13182/NT11-135
+	}
 };
 
 


### PR DESCRIPTION
Fixes issue #7. Issue was in \bibliography{refs} being called as \bibliography{refs.bib}. \bibliography adds the .bib extension, so the bugged version was calling a non-existent file. 

This PR also: 
- Fixes a reference that was throwing a new error. Removing commas between author names fixed this.
- Adds a makefile to ensure errors like this are caught before being uploaded.
- Adds a latex gitignore 